### PR TITLE
Add support for arbitrary params so we can set Content-Encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,9 @@ var plugin = {
                         suffix = 'text';
                 }
                 params['ContentType'] = encoding + '/' + suffix;
+                for (var key in options.params || {}) {
+                  params[key] = options.params[key];
+                }
                 if (file.stat) {
                     params['ContentLength'] = file.stat.size;
                 }


### PR DESCRIPTION
Heya,

Very useful module, best gulp+s3 plugin I've used so far, but would be really great if you could automatically set metadata like `Content-Encoding` for gzipped files.
