### PR TITLE
Allow setting aws key explicitly as a parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ var plugin = {
                 region          : config.region
             });
 
-            if (file.path) {
+            if (!options.key && file.path) {
                 options.key = file.path.replace(file.base, options.path || '');
                 options.key = options.key.replace(new RegExp('\\\\', 'g'), '/');
             }


### PR DESCRIPTION
Very convenient wrapper. Thanks. It would be great to allow to explicitly set the S3 key on upload instead of using the key from file.path with the replacement of file.base.