### PR TITLE
Ensure that every file calls the stream callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ const plugin = {
         callback(err);
       });
 
-      return null;
+      return callback();
     });
   },
 };


### PR DESCRIPTION
After setting up my project that depends on your library on a new machine i notice that it would only upload a subset of files being streamed to it. After debugging and reading the event stream documents I found that this small change fixes it. If you have been using this dependency on the same machine for a long time the old code works fine (presumable some child dependencies have changed).

"Each map MUST call the callback. It may callback with data, with an error or with no arguments" - event-steam docs: https://github.com/dominictarr/event-stream#map-asyncfunction